### PR TITLE
TASK: view-only users can interact with preview and see data in inspector

### DIFF
--- a/Classes/Aspects/AugmentationAspect.php
+++ b/Classes/Aspects/AugmentationAspect.php
@@ -22,6 +22,7 @@ use Neos\Fusion\Service\HtmlAugmenter;
 use Neos\Neos\Domain\Service\ContentContext;
 use Neos\Neos\Ui\Domain\Service\UserLocaleService;
 use Neos\Neos\Ui\Fusion\Helper\NodeInfoHelper;
+use Neos\Neos\Ui\Service\NodePolicyService;
 
 /**
  * - Serialize all nodes related to the currently rendered document
@@ -60,6 +61,12 @@ class AugmentationAspect
      * @var \Neos\Flow\Mvc\Controller\ControllerContext
      */
     protected $controllerContext = null;
+
+    /**
+     * @Flow\Inject
+     * @var NodePolicyService
+     */
+    protected $nodePolicyService;
 
     /**
      * @Flow\Before("method(Neos\Neos\Fusion\ContentElementWrappingImplementation->evaluate())")
@@ -145,7 +152,8 @@ class AugmentationAspect
             return $content;
         }
 
-        if ($this->nodeAuthorizationService->isGrantedToEditNode($node) === false) {
+        // TODO: this is where we could use a feature flag
+        if ($this->nodePolicyService->canReadNode($node) === false) {
             return $content;
         }
 

--- a/Classes/Service/NodePolicyService.php
+++ b/Classes/Service/NodePolicyService.php
@@ -82,6 +82,7 @@ class NodePolicyService
             'disallowedNodeTypes' => $this->getDisallowedNodeTypes($node),
             'canRemove' => $this->canRemoveNode($node),
             'canEdit' => $this->canEditNode($node),
+            'canView' => $this->canReadNode($node),
             'disallowedProperties' => $this->getDisallowedProperties($node)
         ];
     }
@@ -98,6 +99,22 @@ class NodePolicyService
 
         return $this->privilegeManager->isGranted(
             NodeTreePrivilege::class,
+            new NodePrivilegeSubject($node)
+        );
+    }
+
+    /**
+     * @param NodeInterface $node
+     * @return bool
+     */
+    public function canReadNode(NodeInterface $node): bool
+    {
+        if (!isset(self::getUsedPrivilegeClassNames($this->objectManager)[ReadNodePropertyPrivilege::class])) {
+            return true;
+        }
+
+        return $this->privilegeManager->isGranted(
+            ReadNodePropertyPrivilege::class,
             new NodePrivilegeSubject($node)
         );
     }

--- a/packages/neos-ui-ckeditor5-bindings/src/ckEditorApi.js
+++ b/packages/neos-ui-ckeditor5-bindings/src/ckEditorApi.js
@@ -37,12 +37,12 @@ export const bootstrap = _editorConfig => {
 };
 
 export const createEditor = store => async options => {
-    const {propertyDomNode, propertyName, editorOptions, globalRegistry, userPreferences, onChange} = options;
+    const {propertyDomNode, propertyName, editorOptions, globalRegistry, userPreferences, onChange, isReadOnly} = options;
     const ckEditorConfig = editorConfig.configRegistry.getCkeditorConfig({
         editorOptions,
         userPreferences,
         globalRegistry,
-        propertyDomNode
+        propertyDomNode,
     });
 
     class NeosEditor extends DecoupledEditor {
@@ -58,26 +58,34 @@ export const createEditor = store => async options => {
     return NeosEditor
         .create(propertyDomNode, ckEditorConfig)
         .then(editor => {
-            const debouncedOnChange = debounce(() => onChange(cleanupContentBeforeCommit(editor.getData())), 1500, {maxWait: 5000});
-            editor.model.document.on('change:data', debouncedOnChange);
-            editor.ui.focusTracker.on('change:isFocused', event => {
-                if (!event.source.isFocused) {
-                    // when another editor is focused commit all possible pending changes
-                    debouncedOnChange.flush();
-                    return
-                }
+            editor.isReadOnly = isReadOnly;
 
-                currentEditor = editor;
-                editorConfig.setCurrentlyEditedPropertyName(propertyName);
-                handleUserInteractionCallback();
-            });
+            // Set placeholder text as Data if editor is empty because readOnly mode hides the placeholder
+            if (isReadOnly && editor.getData() === '') {
+                editor.setData(ckEditorConfig.placeholder, {doNotFireChange: true});
+            } else {
+                const debouncedOnChange = debounce(() => onChange(cleanupContentBeforeCommit(editor.getData())), 1500, {maxWait: 5000});
+                editor.model.document.on('change:data', debouncedOnChange);
+                editor.ui.focusTracker.on('change:isFocused', event => {
+                    if (!event.source.isFocused) {
+                        // when another editor is focused commit all possible pending changes
+                        debouncedOnChange.flush();
+                        return
+                    }
 
-            editor.keystrokes.set('Ctrl+K', (_, cancel) => {
-                store.dispatch(actions.UI.ContentCanvas.toggleLinkEditor());
-                cancel();
-            });
+                    currentEditor = editor;
+                    editorConfig.setCurrentlyEditedPropertyName(propertyName);
+                    handleUserInteractionCallback();
+                });
 
-            editor.model.document.on('change', () => handleUserInteractionCallback());
+                editor.keystrokes.set('Ctrl+K', (_, cancel) => {
+                    store.dispatch(actions.UI.ContentCanvas.toggleLinkEditor());
+                    cancel();
+                });
+
+                editor.model.document.on('change', () => handleUserInteractionCallback());
+            }
+
             return editor;
         }).catch(e => {
             if (e instanceof TypeError && e.message.match(/Class constructor .* cannot be invoked without 'new'/)) {

--- a/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
+++ b/packages/neos-ui-guest-frame/src/initializeGuestFrame.js
@@ -112,9 +112,11 @@ export default ({globalRegistry, store}) => function * initializeGuestFrame() {
 
     const editPreviewMode = $get(['ui', 'editPreviewMode'], state);
     const editPreviewModes = globalRegistry.get('frontendConfiguration').get('editPreviewModes');
-    const isWorkspaceReadOnly = selectors.CR.Workspaces.isWorkspaceReadOnlySelector(state);
     const currentEditMode = editPreviewModes[editPreviewMode];
-    if (!currentEditMode || !currentEditMode.isEditingMode || isWorkspaceReadOnly) {
+
+    // ReadOnly workspaces are handled by ckEditor directly
+    // TODO: this will break other editors, correct?
+    if (!currentEditMode || !currentEditMode.isEditingMode) {
         return;
     }
 

--- a/packages/neos-ui-guest-frame/src/initializePropertyDomNode.js
+++ b/packages/neos-ui-guest-frame/src/initializePropertyDomNode.js
@@ -4,6 +4,8 @@ import {actions} from '@neos-project/neos-ui-redux-store';
 import {validateElement} from '@neos-project/neos-ui-validators';
 
 import {getGuestFrameWindow, closestContextPathInGuestFrame} from './dom';
+// TODO: this import feels foreign to the rest of neos code, but it feels strange to import the complete selectors object
+import {isWorkspaceReadOnlySelector} from '@neos-project/neos-ui-redux-store/src/CR/Workspaces/selectors';
 
 export default ({store, globalRegistry, nodeTypesRegistry, inlineEditorRegistry, nodes}) => propertyDomNode => {
     const guestFrameWindow = getGuestFrameWindow();
@@ -61,6 +63,7 @@ export default ({store, globalRegistry, nodeTypesRegistry, inlineEditorRegistry,
         try {
             if (!propertyDomNode.dataset.neosInlineEditorIsInitialized) {
                 const userPreferences = $get('user.preferences', store.getState());
+                const isReadOnly = isWorkspaceReadOnlySelector(store.getState());
 
                 createInlineEditor({
                     propertyDomNode,
@@ -70,10 +73,21 @@ export default ({store, globalRegistry, nodeTypesRegistry, inlineEditorRegistry,
                     editorOptions,
                     globalRegistry,
                     userPreferences,
-                    persistChange: change => store.dispatch(
-                        actions.Changes.persistChanges([change])
-                    ),
+                    isReadOnly,
+                    persistChange: change => {
+                        if (isReadOnly) {
+                            return;
+                        }
+
+                        store.dispatch(
+                            actions.Changes.persistChanges([change])
+                        )
+                    },
                     onChange: value => {
+                        if (isReadOnly) {
+                            return;
+                        }
+
                         const validationResult = validateElement(value, $get(['properties', propertyName], nodeType), globalRegistry.get('validators'));
                         // Update inline validation errors
                         store.dispatch(

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/TabPanel/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/TabPanel/index.js
@@ -30,7 +30,7 @@ export default class TabPanel extends PureComponent {
             return false;
         }
 
-        return $get(['policy', 'canEdit'], node) && !$contains(item.id, 'policy.disallowedProperties', node);
+        return $get(['policy', 'canView'], node) && !$contains(item.id, 'policy.disallowedProperties', node);
     };
 
     renderTabPanel = groups => {

--- a/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
+++ b/packages/neos-ui/src/Containers/RightSideBar/Inspector/index.js
@@ -247,7 +247,7 @@ export default class Inspector extends PureComponent {
             return false;
         }
 
-        return $get(['policy', 'canEdit'], focusedNode) && !$contains(item.id, 'policy.disallowedProperties', focusedNode);
+        return $get(['policy', 'canView'], focusedNode) && !$contains(item.id, 'policy.disallowedProperties', focusedNode);
     };
 
     /**


### PR DESCRIPTION
> _**WHY this fork**_
>
> This fork seems necessary because I can't use a neos branch other than 8.4.x because some other composer packages rely on it. So `"neos/neos-ui": "dev-my-patch-branch"` prevents `composer install` from successfully installing.
> 
> My simple fix is to 
> 1. fork 
> 2. merge the PR into 8.4 (with this having a base to create a PR for upstream)
> 3. use this fork in composer json `"repositories"`.

**Previously:** 

1. When  a view-only user interacts with nodes on the preview page - nothing happens. 
    - The user can only select nodes via the content tree (right sidebar)
2. The user could not see any node data in the inspector

**Now:**

1. The user can interact with nodes on the preview page
2. The user can view - but not edit - node data in the inspector
3. Editing node data by changing html manually on the running page results in Error (forbidden) in all my manual tests (might have missed something, though)

<!--
Thanks for your contribution, we appreciate it!

ATTENTION: ALL NEW FEATURE PRs SHOULD TARGET THE MASTER BRANCH (bugfixes go to the least maintained branch)
-->


**What I did**
- I let the backend send metadata to the client when the user has permission to read (previously it was only sent, when the user had permission to edit).
- I handle the read-only case in CKEditor to prevent the user from editing and throwing errors that way.
- This should also apply to read-only workspaces

**How I did it**

**How to verify it**

<!--
If possible, a screenshot or a gif comparing the new and old behavior would be great.
-->
